### PR TITLE
Pasts 0.12.0; `Microphone`, `Speakers` as `Notifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://jeronlau.tk/semver/).
 
 ## [0.10.0] - Unreleased
+### Added
+ - Impl `Notifier<Event = SpeakersSink>` for `Speakers`
+ - Impl `Notifier<Event = MicrophoneStream>` for `Microphone`
+
 ### Changed
  - Update to pasts 0.12.0
  - Replace `supports()` with `config()`
+
+### Removed
+ - `Speakers::play()` - use `Notifier` impl on `Speakers` instead
+ - `Microphone::record()` - use `Notifier` impl on `Microphone` instead
 
 ## [0.9.1] - 2021-02-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `wavy` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://jeronlau.tk/semver/).
 
+## [0.10.0] - Unreleased
+### Changed
+ - Update to pasts 0.12.0
+ - Replace `supports()` with `config()`
+
 ## [0.9.1] - 2021-02-06
 ### Fixed
  - Panics in the Web port

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ edition = "2018"
 [dependencies.fon]
 version = "0.5"
 
+[dependencies.pasts]
+version = "0.12"
+
 # For Linux and Android
 [target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "linux", target_os = "android")))'.dependencies]
 smelling_salts = "0.2"
@@ -59,5 +62,4 @@ version = "0.2"
 
 # Examples
 [dev-dependencies]
-pasts = "0.7"
 twang = "0.7"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+// Purposely not included when publishing; for tests/examples only
+fn main() {
+    let async_main = format!("{}/main.rs", std::env::var("OUT_DIR").unwrap());
+    std::fs::write(
+        async_main,
+        r#"
+        #[cfg_attr(feature = "pasts/web", wasm_bindgen(start))]
+        pub fn main() {
+            let executor = Executor::default();
+            executor.spawn(App::main(executor.clone()));
+        }"#,
+    )
+    .unwrap();
+}

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -1,44 +1,50 @@
 // This example records audio and plays it back in real time as it's being
 // recorded.
 
+// Setup async main
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+
 use fon::{mono::Mono32, Audio, Sink};
-use pasts::exec;
+use pasts::{prelude::*, Join};
 use wavy::{Microphone, MicrophoneStream, Speakers, SpeakersSink};
 
-/// An event handled by the event loop.
-enum Event<'a> {
-    /// Speaker is ready to play more audio.
-    Play(SpeakersSink<'a, Mono32>),
-    /// Microphone has recorded some audio.
-    Record(MicrophoneStream<'a, Mono32>),
-}
-
 /// Shared state between tasks on the thread.
-struct State {
+struct App<'a> {
+    /// Handle to speakers
+    speakers: &'a mut Speakers<1>,
+    /// Handle to the microphone
+    microphone: &'a mut Microphone<1>,
     /// Temporary buffer for holding real-time audio samples.
     buffer: Audio<Mono32>,
 }
 
-impl State {
-    /// Event loop.
-    fn event(&mut self, event: Event<'_>) {
-        match event {
-            Event::Play(mut speakers) => speakers.stream(self.buffer.drain()),
-            Event::Record(microphone) => self.buffer.extend(microphone),
-        }
+impl App<'_> {
+    /// Speaker is ready to play more audio.
+    fn play(&mut self, mut sink: SpeakersSink<Mono32>) -> Poll<()> {
+        sink.stream(self.buffer.drain());
+        Pending
     }
-}
 
-/// Program start.
-fn main() {
-    let mut state = State {
-        buffer: Audio::with_silence(48_000, 0),
-    };
-    let mut speakers = Speakers::default();
-    let mut microphone = Microphone::default();
+    /// Microphone has recorded some audio.
+    fn record(&mut self, stream: MicrophoneStream<Mono32>) -> Poll<()> {
+        self.buffer.extend(stream);
+        Pending
+    }
 
-    exec!(state.event(pasts::wait! {
-        Event::Play(speakers.play().await),
-        Event::Record(microphone.record().await),
-    }))
+    /// Program start.
+    async fn main(_executor: Executor) {
+        let speakers = &mut Speakers::default();
+        let microphone = &mut Microphone::default();
+        let buffer = Audio::with_silence(48_000, 0);
+        let mut app = App {
+            speakers,
+            microphone,
+            buffer,
+        };
+
+        Join::new(&mut app)
+            .on(|s| s.speakers, App::play)
+            .on(|s| s.microphone, App::record)
+            .await
+    }
 }

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -1,43 +1,38 @@
 // Play a 220 Hertz sine wave through the system's speakers.
 
+// Setup async main
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+
 use fon::{stereo::Stereo32, Sink};
-use pasts::{exec, wait};
+use pasts::{prelude::*, Join};
 use twang::{Fc, Signal, Synth};
 use wavy::{Speakers, SpeakersSink};
 
-/// An event handled by the event loop.
-enum Event<'a> {
-    /// Speaker is ready to play more audio.
-    Play(SpeakersSink<'a, Stereo32>),
-}
-
 /// Shared state between tasks on the thread.
-struct State {
+struct App<'a> {
+    /// Handle to stereo speakers
+    speakers: &'a mut Speakers<2>,
     /// A streaming synthesizer using Twang.
     synth: Synth<()>,
 }
 
-impl State {
-    /// Event loop.  Return false to stop program.
-    fn event(&mut self, event: Event<'_>) {
-        match event {
-            Event::Play(mut speakers) => speakers.stream(&mut self.synth),
+impl App<'_> {
+    /// Speaker is ready to play more audio.
+    fn play(&mut self, mut sink: SpeakersSink<Stereo32>) -> Poll<()> {
+        sink.stream(&mut self.synth);
+        Pending
+    }
+
+    /// Program start.
+    async fn main(_executor: Executor) {
+        fn sine(_: &mut (), fc: Fc) -> Signal {
+            fc.freq(440.0).sine().gain(0.7)
         }
+
+        let speakers = &mut Speakers::default();
+        let synth = Synth::new((), sine);
+        let mut app = App { speakers, synth };
+
+        Join::new(&mut app).on(|s| s.speakers, App::play).await;
     }
-}
-
-/// Program start.
-fn main() {
-    fn sine(_: &mut (), fc: Fc) -> Signal {
-        fc.freq(440.0).sine().gain(0.7)
-    }
-
-    let mut state = State {
-        synth: Synth::new((), sine),
-    };
-    let mut speakers = Speakers::default();
-
-    exec!(state.event(wait! {
-        Event::Play(speakers.play().await),
-    }));
 }

--- a/examples/play/Cargo.toml
+++ b/examples/play/Cargo.toml
@@ -28,7 +28,7 @@ wee_alloc = { version = "0.4.5", optional = true }
 
 # To play audio
 fon = "0.5"
-pasts = "0.7"
+pasts = { version = "0.12", features = ["web"] }
 twang = "0.7"
 wavy = { path = "../.." }
 

--- a/examples/play/build.rs
+++ b/examples/play/build.rs
@@ -1,0 +1,14 @@
+// Purposely not included when publishing; for tests/examples only
+fn main() {
+    let async_main = format!("{}/main.rs", std::env::var("OUT_DIR").unwrap());
+    std::fs::write(
+        async_main,
+        r#"
+        #[cfg_attr(feature = "pasts/web", wasm_bindgen(start))]
+        pub fn main() {
+            let executor = Executor::default();
+            executor.spawn(App::main(executor.clone()));
+        }"#,
+    )
+    .unwrap();
+}

--- a/examples/play/site/index.html
+++ b/examples/play/site/index.html
@@ -3,11 +3,15 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
+    <script>
+      var start_main = null;
+    </script>
     <script type="module">
         import init, {wasm_start_main} from './gen/play.js';
         init().then(function(wasm) {
-            wasm_start_main();
+            start_main = wasm_start_main;
         });
     </script>
+    <button onclick="start_main()">Start</button>
   </body>
 </html>

--- a/examples/play/src/main.rs
+++ b/examples/play/src/main.rs
@@ -1,41 +1,38 @@
 // Play a 220 Hertz sine wave through the system's speakers.
 
+// Setup async main
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+
 use fon::{stereo::Stereo32, Sink};
-use pasts::{exec, wait};
+use pasts::{prelude::*, Join};
 use twang::{Fc, Signal, Synth};
 use wavy::{Speakers, SpeakersSink};
 
-/// An event handled by the event loop.
-enum Event<'a> {
-    /// Speaker is ready to play more audio.
-    Play(SpeakersSink<'a, Stereo32>),
-}
-
 /// Shared state between tasks on the thread.
-struct State {
+struct App<'a> {
+    /// Handle to stereo speakers
+    speakers: &'a mut Speakers<2>,
     /// A streaming synthesizer using Twang.
     synth: Synth<()>,
 }
 
-impl State {
-    /// Event loop.  Return false to stop program.
-    fn event(&mut self, event: Event<'_>) {
-        match event {
-            Event::Play(mut speakers) => speakers.stream(&mut self.synth),
+impl App<'_> {
+    /// Speaker is ready to play more audio.
+    fn play(&mut self, mut sink: SpeakersSink<Stereo32>) -> Poll<()> {
+        sink.stream(&mut self.synth);
+        Pending
+    }
+
+    /// Program start.
+    async fn main(_executor: Executor) {
+        fn sine(_: &mut (), fc: Fc) -> Signal {
+            fc.freq(440.0).sine().gain(0.7)
         }
+
+        let speakers = &mut Speakers::default();
+        let synth = Synth::new((), sine);
+        let mut app = App { speakers, synth };
+
+        Join::new(&mut app).on(|s| s.speakers, App::play).await;
     }
-}
-
-/// Program start.
-fn main() {
-    fn sine(_: &mut (), fc: Fc) -> Signal {
-        fc.freq(440.0).sine().gain(0.7)
-    }
-
-    let mut state = State { synth: Synth::new((), sine) };
-    let mut speakers = Speakers::default();
-
-    exec!(state.event(wait! {
-        Event::Play(speakers.play().await),
-    }));
 }

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,24 +1,26 @@
 use wavy::{Microphone, Speakers};
 
 fn main() {
-    for speakers in Speakers::query() {
+    for speakers in Speakers::<0>::query() {
         println!("Found speaker: {}", speakers);
 
-        if speakers.supports::<fon::mono::Mono32>() {
+        // FIXME
+        /*if speakers.config::<fon::mono::Mono32>() {
             println!(" - Mono");
         }
-        if speakers.supports::<fon::stereo::Stereo32>() {
+        if speakers.config::<fon::stereo::Stereo32>() {
             println!(" - Stereo");
         }
-        if speakers.supports::<fon::surround::Surround32>() {
+        if speakers.config::<fon::surround::Surround32>() {
             println!(" - Surround");
-        }
+        }*/
     }
 
-    for microphone in Microphone::query() {
+    for microphone in Microphone::<0>::query() {
         println!("Found microphone: {}", microphone);
 
-        if microphone.supports::<fon::mono::Mono32>() {
+        // FIXME
+        /*if microphone.supports::<fon::mono::Mono32>() {
             println!(" - Mono");
         }
         if microphone.supports::<fon::stereo::Stereo32>() {
@@ -26,6 +28,6 @@ fn main() {
         }
         if microphone.supports::<fon::surround::Surround32>() {
             println!(" - Surround");
-        }
+        }*/
     }
 }

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,7 +1,7 @@
 use wavy::{Microphone, Speakers};
 
 fn main() {
-    for speakers in Speakers::<0>::query() {
+    for speakers in Speakers::query() {
         println!("Found speaker: {}", speakers);
 
         // FIXME
@@ -16,7 +16,7 @@ fn main() {
         }*/
     }
 
-    for microphone in Microphone::<0>::query() {
+    for microphone in Microphone::query() {
         println!("Found microphone: {}", microphone);
 
         // FIXME

--- a/examples/record.rs
+++ b/examples/record.rs
@@ -1,34 +1,38 @@
 // This example records audio for 5 seconds and writes to a raw PCM file.
 
+// Setup async main
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+
 use fon::{mono::Mono32, Audio, Frame};
-use pasts::{exec, wait};
+use pasts::{prelude::*, Join};
 use wavy::{Microphone, MicrophoneStream};
 
-/// An event handled by the event loop.
-enum Event<'a> {
-    /// Microphone has recorded some audio.
-    Record(MicrophoneStream<'a, Mono32>),
-}
-
 /// Shared state between tasks on the thread.
-struct State {
+struct App<'a> {
+    /// Handle to the mono microphone
+    microphone: &'a mut Microphone<1>,
     /// Temporary buffer for holding real-time audio samples.
     buffer: Audio<Mono32>,
 }
 
-impl State {
+impl App<'_> {
     /// Event loop.  Return false to stop program.
-    fn event(&mut self, event: Event<'_>) {
-        match event {
-            Event::Record(microphone) => {
-                //println!("Recording");
-                self.buffer.extend(microphone);
-                if self.buffer.len() >= 48_000 * 10 {
-                    write_pcm(&self.buffer);
-                    std::process::exit(0);
-                }
-            }
+    fn record(&mut self, stream: MicrophoneStream<Mono32>) -> Poll<()> {
+        self.buffer.extend(stream);
+        if self.buffer.len() >= 48_000 * 10 {
+            return Ready(());
         }
+        Pending
+    }
+
+    async fn main(_executor: Executor) {
+        let buffer = Audio::with_silence(48_000, 0);
+        let microphone = &mut Microphone::default();
+        let mut app = App { buffer, microphone };
+
+        Join::new(&mut app).on(|s| s.microphone, App::record).await;
+
+        write_pcm(&app.buffer);
     }
 }
 
@@ -40,16 +44,4 @@ fn write_pcm(buffer: &Audio<Mono32>) {
         pcm.extend(sample.to_le_bytes().iter());
     }
     std::fs::write("pcm.raw", pcm.as_slice()).expect("Failed to write file");
-}
-
-/// Program start.
-fn main() {
-    let mut state = State {
-        buffer: Audio::with_silence(48_000, 0),
-    };
-    let mut microphone = Microphone::default();
-
-    exec!(state.event(wait! {
-        Event::Record(microphone.record().await),
-    }))
 }

--- a/examples/record/Cargo.toml
+++ b/examples/record/Cargo.toml
@@ -28,7 +28,7 @@ wee_alloc = { version = "0.4.5", optional = true }
 
 # To play audio
 fon = "0.5"
-pasts = "0.7"
+pasts = { version = "0.12", features = ["web"] }
 wavy = { path = "../.." }
 
 [dev-dependencies]

--- a/examples/record/build.rs
+++ b/examples/record/build.rs
@@ -1,0 +1,14 @@
+// Purposely not included when publishing; for tests/examples only
+fn main() {
+    let async_main = format!("{}/main.rs", std::env::var("OUT_DIR").unwrap());
+    std::fs::write(
+        async_main,
+        r#"
+        #[cfg_attr(feature = "pasts/web", wasm_bindgen(start))]
+        pub fn main() {
+            let executor = Executor::default();
+            executor.spawn(App::main(executor.clone()));
+        }"#,
+    )
+    .unwrap();
+}

--- a/examples/record/site/index.html
+++ b/examples/record/site/index.html
@@ -3,11 +3,15 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
+    <script>
+      var start_main = null;
+    </script>
     <script type="module">
         import init, {wasm_start_main} from './gen/record.js';
         init().then(function(wasm) {
-            wasm_start_main();
+            start_main = wasm_start_main;
         });
     </script>
+    <button onclick="start_main()">Start</button>
   </body>
 </html>

--- a/examples/record/src/main.rs
+++ b/examples/record/src/main.rs
@@ -1,42 +1,50 @@
 // This example records audio and plays it back in real time as it's being
 // recorded.
 
+// Setup async main
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+
 use fon::{mono::Mono32, Audio, Sink};
-use pasts::exec;
+use pasts::{prelude::*, Join};
 use wavy::{Microphone, MicrophoneStream, Speakers, SpeakersSink};
 
-/// An event handled by the event loop.
-enum Event<'a> {
-    /// Speaker is ready to play more audio.
-    Play(SpeakersSink<'a, Mono32>),
-    /// Microphone has recorded some audio.
-    Record(MicrophoneStream<'a, Mono32>),
-}
-
 /// Shared state between tasks on the thread.
-struct State {
+struct App<'a> {
+    /// Handle to speakers
+    speakers: &'a mut Speakers<1>,
+    /// Handle to the microphone
+    microphone: &'a mut Microphone<1>,
     /// Temporary buffer for holding real-time audio samples.
     buffer: Audio<Mono32>,
 }
 
-impl State {
-    /// Event loop.
-    fn event(&mut self, event: Event<'_>) {
-        match event {
-            Event::Play(mut speakers) => speakers.stream(self.buffer.drain()),
-            Event::Record(microphone) => self.buffer.extend(microphone),
-        }
+impl App<'_> {
+    /// Speaker is ready to play more audio.
+    fn play(&mut self, mut sink: SpeakersSink<Mono32>) -> Poll<()> {
+        sink.stream(self.buffer.drain());
+        Pending
     }
-}
 
-/// Program start.
-fn main() {
-    let mut state = State { buffer: Audio::with_silence(48_000, 0) };
-    let mut speakers = Speakers::default();
-    let mut microphone = Microphone::default();
+    /// Microphone has recorded some audio.
+    fn record(&mut self, stream: MicrophoneStream<Mono32>) -> Poll<()> {
+        self.buffer.extend(stream);
+        Pending
+    }
 
-    exec!(state.event(pasts::wait! {
-        Event::Play(speakers.play().await),
-        Event::Record(microphone.record().await),
-    }))
+    /// Program start.
+    async fn main(_executor: Executor) {
+        let speakers = &mut Speakers::default();
+        let microphone = &mut Microphone::default();
+        let buffer = Audio::with_silence(48_000, 0);
+        let mut app = App {
+            speakers,
+            microphone,
+            buffer,
+        };
+
+        Join::new(&mut app)
+            .on(|s| s.speakers, App::play)
+            .on(|s| s.microphone, App::record)
+            .await
+    }
 }

--- a/src/ffi/dummy/microphone.rs
+++ b/src/ffi/dummy/microphone.rs
@@ -40,7 +40,7 @@ impl Default for Microphone {
 impl Microphone {
     pub(crate) fn record<F: Frame<Chan = Ch32>>(
         &mut self,
-    ) -> MicrophoneStream<'_, F> {
+    ) -> MicrophoneStream<F> {
         MicrophoneStream(PhantomData)
     }
 
@@ -57,11 +57,11 @@ impl Future for Microphone {
     }
 }
 
-pub(crate) struct MicrophoneStream<'a, F: Frame<Chan = Ch32>>(
-    PhantomData<&'a F>,
+pub(crate) struct MicrophoneStream<F: Frame<Chan = Ch32>>(
+    PhantomData<&'static F>,
 );
 
-impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<F> {
     type Item = F;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -69,7 +69,7 @@ impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<'_, F> {
     }
 }
 
-impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<F> {
     fn sample_rate(&self) -> Option<f64> {
         Some(crate::consts::SAMPLE_RATE.into())
     }

--- a/src/ffi/linux/microphone.rs
+++ b/src/ffi/linux/microphone.rs
@@ -26,7 +26,7 @@ use super::{
     DEFAULT,
 };
 
-pub(crate) struct Microphone {
+struct MicrophoneInner {
     // PCM I/O Handle
     device: AudioDevice,
     // Interleaved Audio Buffer.
@@ -35,43 +35,68 @@ pub(crate) struct Microphone {
     period: u16,
     // Index to stop reading.
     endi: usize,
+    /// Microphone are locked
+    locked: AtomicBool,
+}
+
+pub(crate) struct Microphone {
     // Number of channels on the Microphone.
     pub(crate) channels: u8,
     // Sample Rate of The Microphone (src)
     pub(crate) sample_rate: Option<f64>,
-    /// Microphone are locked
-    locked: AtomicBool,
+    /// Leaked shared box
+    inner: *mut MicrophoneInner,
+}
+
+impl Drop for Microphone {
+    fn drop(&mut self) {
+        // Safety
+        if unsafe { (*self.inner).locked.load(SeqCst) } {
+            eprintln!("Microphone dropped before dropping stream");
+            std::process::exit(1);
+        }
+
+        unsafe { drop(Box::from_raw(self.inner)) };
+    }
 }
 
 impl SoundDevice for Microphone {
     const INPUT: bool = true;
 
     fn pcm(&self) -> *mut c_void {
-        self.device.pcm
+        unsafe { (*self.inner).device.pcm }
     }
 
     fn hwp(&self) -> *mut c_void {
-        self.device.pcm
+        unsafe { (*self.inner).device.pcm }
+    }
+}
+
+impl Display for Microphone {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        // Safety
+        if unsafe { (*self.inner).locked.load(SeqCst) } {
+            eprintln!("Tried to display speakers before dropping sink");
+            std::process::exit(1);
+        }
+
+        unsafe { f.write_str((*self.inner).device.name.as_str()) }
     }
 }
 
 impl From<AudioDevice> for Microphone {
     fn from(device: AudioDevice) -> Self {
         Self {
-            device,
-            buffer: Vec::new(),
-            period: 0,
             channels: 0,
-            endi: 0,
             sample_rate: None,
-            locked: AtomicBool::new(false),
+            inner: Box::leak(Box::new(MicrophoneInner {
+                device,
+                buffer: Vec::new(),
+                period: 0,
+                endi: 0,
+                locked: AtomicBool::new(false),
+            })),
         }
-    }
-}
-
-impl Display for Microphone {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        f.write_str(self.device.name.as_str())
     }
 }
 
@@ -92,7 +117,7 @@ impl Default for Microphone {
 
 impl Microphone {
     /// Attempt to configure the microphone for a specific number of channels.
-    fn set_channels<F>(&mut self) -> Option<bool>
+    fn set_channels<F>(&mut self, inner: &mut MicrophoneInner) -> Option<bool>
     where
         F: Frame<Chan = Ch32>,
     {
@@ -103,11 +128,11 @@ impl Microphone {
             self.channels = F::CHAN_COUNT as u8;
             // Configure Hardware Parameters
             pcm_hw_params(
-                &self.device,
+                &inner.device,
                 self.channels,
-                &mut self.buffer,
+                &mut inner.buffer,
                 &mut self.sample_rate,
-                &mut self.period,
+                &mut inner.period,
             )?;
             Some(true)
         } else {
@@ -118,16 +143,25 @@ impl Microphone {
     pub(crate) fn record<F: Frame<Chan = Ch32>>(
         &mut self,
     ) -> MicrophoneStream<F> {
+        // Always called after ready, so should be safe
+        let inner = unsafe { self.inner.as_mut().unwrap() };
+        
         // Change number of channels, if different than last call.
-        self.set_channels::<F>()
+        self.set_channels::<F>(inner)
             .expect("Microphone::record() called with invalid configuration");
 
         // Stream from microphone's buffer.
-        MicrophoneStream(self, 0, PhantomData)
+        MicrophoneStream(inner, 0, PhantomData, self.sample_rate, self.channels)
     }
 
     pub(crate) fn channels(&self) -> u8 {
-        self.device.supported
+        // Safety
+        if unsafe { (*self.inner).locked.load(SeqCst) } {
+            eprintln!("Tried to poll speakers before dropping sink");
+            std::process::exit(1);
+        }
+
+        unsafe { (*self.inner).device.supported }
     }
 }
 
@@ -140,21 +174,23 @@ impl Future for Microphone {
         let this = self.get_mut();
 
         // Safety
-        if this.locked.load(SeqCst) {
+        if unsafe { (*this.inner).locked.load(SeqCst) } {
             eprintln!("Tried to poll microphone before dropping stream");
             std::process::exit(1);
         }
+        //
+        let inner = unsafe { this.inner.as_mut().unwrap() };
 
         // If microphone is unconfigured, return Ready to configure and play.
         if this.channels == 0 {
-            let _ = this.device.start();
-            this.locked.store(true, SeqCst);
+            let _ = inner.device.start();
+            inner.locked.store(true, SeqCst);
             return Poll::Ready(());
         }
 
         // Check if not woken, then yield.
         let mut pending = true;
-        for fd in &this.device.fds {
+        for fd in &inner.device.fds {
             if !fd.should_yield() {
                 pending = false;
                 break;
@@ -167,9 +203,9 @@ impl Future for Microphone {
         // Attempt to overwrite the internal microphone buffer.
         let result = unsafe {
             asound::pcm::readi(
-                this.device.pcm,
-                this.buffer.as_mut_slice().as_mut_ptr(),
-                this.period,
+                inner.device.pcm,
+                inner.buffer.as_mut_slice().as_mut_ptr(),
+                inner.period,
             )
         };
 
@@ -189,11 +225,11 @@ impl Future for Microphone {
                         unreachable!()
                     }
                     -32 => {
-                        match unsafe { asound::pcm::state(this.device.pcm) } {
+                        match unsafe { asound::pcm::state(inner.device.pcm) } {
                             SndPcmState::Xrun => {
                                 eprintln!("Microphone XRUN: Latency cause?");
                                 unsafe {
-                                    asound::pcm::prepare(this.device.pcm)
+                                    asound::pcm::prepare(inner.device.pcm)
                                         .unwrap();
                                 }
                             }
@@ -212,15 +248,15 @@ impl Future for Microphone {
                         "Stream got suspended, trying to recover… (-ESTRPIPE)"
                     );
                         unsafe {
-                            if asound::pcm::resume(this.device.pcm).is_ok() {
+                            if asound::pcm::resume(inner.device.pcm).is_ok() {
                                 // Prepare, so we keep getting samples.
-                                asound::pcm::prepare(this.device.pcm).unwrap();
+                                asound::pcm::prepare(inner.device.pcm).unwrap();
                             }
                         }
                     }
                     _ => unreachable!(),
                 }
-                for fd in &this.device.fds {
+                for fd in &inner.device.fds {
                     // Register waker
                     fd.register_waker(cx.waker());
                 }
@@ -228,9 +264,9 @@ impl Future for Microphone {
                 Poll::Pending
             }
             Ok(len) => {
-                this.endi = len;
+                inner.endi = len;
                 // Ready, audio buffer has been filled!
-                this.locked.store(true, SeqCst);
+                inner.locked.store(true, SeqCst);
                 Poll::Ready(())
             }
         }
@@ -238,9 +274,11 @@ impl Future for Microphone {
 }
 
 pub(crate) struct MicrophoneStream<F: Frame<Chan = Ch32>>(
-    *mut Microphone,
+    *mut MicrophoneInner,
     usize,
     PhantomData<F>,
+    Option<f64>,
+    u8,
 );
 
 impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<F> {
@@ -252,7 +290,7 @@ impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<F> {
             return None;
         }
         let frame =
-            F::from_channels(&mic.buffer[self.1 * mic.channels as usize..]);
+            F::from_channels(&mic.buffer[self.1 * self.4 as usize..]);
         self.1 += 1;
         Some(frame)
     }
@@ -260,8 +298,7 @@ impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<F> {
 
 impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<F> {
     fn sample_rate(&self) -> Option<f64> {
-        let mic = unsafe { self.0.as_mut().unwrap() };
-        mic.sample_rate
+        self.3
     }
 
     fn len(&self) -> Option<usize> {

--- a/src/ffi/linux/speakers.rs
+++ b/src/ffi/linux/speakers.rs
@@ -30,8 +30,7 @@ use super::{
     DEFAULT,
 };
 
-/// ALSA Speakers connection.
-pub(crate) struct Speakers {
+struct SpeakersInner {
     /// ALSA PCM type for both speakers and microphones.
     device: AudioDevice,
     /// Index into audio frames to start writing.
@@ -42,43 +41,69 @@ pub(crate) struct Speakers {
     resampler: ([Ch32; 6], f64),
     /// The number of frames in the buffer.
     period: u16,
+    /// Speakers are locked
+    locked: AtomicBool,
+}
+
+/// ALSA Speakers connection.
+pub(crate) struct Speakers {
     /// Number of available channels
     pub(crate) channels: u8,
     /// The sample rate of the speakers.
     pub(crate) sample_rate: Option<f64>,
-    /// Speakers are locked
-    locked: AtomicBool,
+    /// Leaked shared box
+    inner: *mut SpeakersInner,
+}
+
+impl Drop for Speakers {
+    fn drop(&mut self) {
+        // Safety
+        if unsafe { (*self.inner).locked.load(SeqCst) } {
+            eprintln!("Speakers dropped before dropping sink");
+            std::process::exit(1);
+        }
+
+        unsafe { drop(Box::from_raw(self.inner)) };
+    }
 }
 
 impl SoundDevice for Speakers {
     const INPUT: bool = false;
 
     fn pcm(&self) -> *mut c_void {
-        self.device.pcm
+        unsafe { (*self.inner).device.pcm }
     }
 
     fn hwp(&self) -> *mut c_void {
-        self.device.pcm
+        unsafe { (*self.inner).device.pcm }
     }
 }
 
 impl Display for Speakers {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        f.write_str(self.device.name.as_str())
+        // Safety
+        if unsafe { (*self.inner).locked.load(SeqCst) } {
+            eprintln!("Tried to display speakers before dropping sink");
+            std::process::exit(1);
+        }
+
+        unsafe { f.write_str((*self.inner).device.name.as_str()) }
     }
 }
 
 impl From<AudioDevice> for Speakers {
     fn from(device: AudioDevice) -> Self {
         Self {
-            device,
-            starti: 0,
-            buffer: Vec::new(),
             sample_rate: None,
             channels: 0,
-            resampler: ([Ch32::MID; 6], 0.0),
-            period: 0,
-            locked: AtomicBool::new(false),
+            inner: Box::leak(Box::new(SpeakersInner {
+                device,
+                starti: 0,
+                buffer: Vec::new(),
+                resampler: ([Ch32::MID; 6], 0.0),
+                period: 0,
+                locked: AtomicBool::new(false),
+            })),
         }
     }
 }
@@ -100,7 +125,7 @@ impl Default for Speakers {
 
 impl Speakers {
     /// Attempt to configure the speaker for a specific number of channels.
-    fn set_channels<F>(&mut self) -> Option<bool>
+    fn set_channels<F>(&mut self, inner: &mut SpeakersInner) -> Option<bool>
     where
         F: Frame<Chan = Ch32>,
     {
@@ -111,11 +136,11 @@ impl Speakers {
             self.channels = F::CHAN_COUNT as u8;
             // Configure Hardware Parameters
             pcm_hw_params(
-                &self.device,
+                &inner.device,
                 self.channels,
-                &mut self.buffer,
+                &mut inner.buffer,
                 &mut self.sample_rate,
-                &mut self.period,
+                &mut inner.period,
             )?;
             Some(true)
         } else {
@@ -128,20 +153,28 @@ impl Speakers {
     where
         F: Frame<Chan = Ch32>,
     {
+        // Always called after ready, so should be safe
+        let inner = unsafe { self.inner.as_mut().unwrap() };
         // Change number of channels, if different than last call.
-        self.set_channels::<F>()
+        self.set_channels::<F>(inner)
             .expect("Speaker::play() called with invalid configuration");
         // Convert the resampler to the target speaker configuration.
         let resampler = Resampler::<F>::new(
-            Surround32::from_channels(&self.resampler.0[..]).convert(),
-            self.resampler.1,
+            Surround32::from_channels(&inner.resampler.0[..]).convert(),
+            inner.resampler.1,
         );
         // Create a sink that borrows this speaker's buffer mutably.
-        SpeakersSink(self, resampler, PhantomData)
+        SpeakersSink(inner, resampler, PhantomData, self.sample_rate.unwrap())
     }
 
     pub(crate) fn channels(&self) -> u8 {
-        self.device.supported
+        // Safety
+        if unsafe { (*self.inner).locked.load(SeqCst) } {
+            eprintln!("Tried to poll speakers before dropping sink");
+            std::process::exit(1);
+        }
+
+        unsafe { (*self.inner).device.supported }
     }
 }
 
@@ -153,21 +186,23 @@ impl Future for Speakers {
         let this = self.get_mut();
 
         // Safety
-        if this.locked.load(SeqCst) {
+        if unsafe { (*this.inner).locked.load(SeqCst) } {
             eprintln!("Tried to poll speakers before dropping sink");
             std::process::exit(1);
         }
+        //
+        let inner = unsafe { this.inner.as_mut().unwrap() };
 
         // If speaker is unconfigured, return Ready to configure and play.
         if this.channels == 0 {
-            let _ = this.device.start();
-            this.locked.store(true, SeqCst);
+            let _ = inner.device.start();
+            inner.locked.store(true, SeqCst);
             return Poll::Ready(());
         }
 
         // Check if not woken, then yield.
         let mut pending = true;
-        for fd in &this.device.fds {
+        for fd in &inner.device.fds {
             if !fd.should_yield() {
                 pending = false;
                 break;
@@ -181,9 +216,9 @@ impl Future for Speakers {
         // Attempt to write remaining internal speaker buffer to the speakers.
         let result = unsafe {
             asound::pcm::writei(
-                this.device.pcm,
-                this.buffer.as_ptr(),
-                this.period.into(),
+                inner.device.pcm,
+                inner.buffer.as_ptr(),
+                inner.period.into(),
             )
         };
 
@@ -197,23 +232,23 @@ impl Future for Speakers {
                     // page)
                     -11 => {
                         /* Pending */
-                        for fd in &this.device.fds {
+                        for fd in &inner.device.fds {
                             // Register waker, and then return not ready.
                             fd.register_waker(cx.waker());
                         }
                         return Poll::Pending;
                     }
                     -32 => {
-                        match unsafe { asound::pcm::state(this.device.pcm) } {
+                        match unsafe { asound::pcm::state(inner.device.pcm) } {
                             SndPcmState::Xrun => {
                                 // Player samples are not generated fast enough
                                 unsafe {
-                                    asound::pcm::prepare(this.device.pcm)
+                                    asound::pcm::prepare(inner.device.pcm)
                                         .unwrap();
                                     asound::pcm::writei(
-                                        this.device.pcm,
-                                        this.buffer.as_ptr(),
-                                        this.period.into(),
+                                        inner.device.pcm,
+                                        inner.buffer.as_ptr(),
+                                        inner.period.into(),
                                     )
                                     .unwrap()
                                 }
@@ -244,13 +279,13 @@ impl Future for Speakers {
                         // Prepare, so we keep getting samples.
                         unsafe {
                             // Whether this works or not, we want to prepare.
-                            let _ = asound::pcm::resume(this.device.pcm);
+                            let _ = asound::pcm::resume(inner.device.pcm);
                             // Prepare
-                            asound::pcm::prepare(this.device.pcm).unwrap();
+                            asound::pcm::prepare(inner.device.pcm).unwrap();
                             asound::pcm::writei(
-                                this.device.pcm,
-                                this.buffer.as_ptr(),
-                                this.period.into(),
+                                inner.device.pcm,
+                                inner.buffer.as_ptr(),
+                                inner.period.into(),
                             )
                             .unwrap()
                         }
@@ -261,26 +296,27 @@ impl Future for Speakers {
         };
 
         // Shift buffer.
-        this.buffer.drain(..len * this.channels as usize);
-        this.starti = this.buffer.len() / this.channels as usize;
-        this.buffer
-            .resize(this.period as usize * this.channels as usize, Ch32::MID);
+        inner.buffer.drain(..len * this.channels as usize);
+        inner.starti = inner.buffer.len() / this.channels as usize;
+        inner
+            .buffer
+            .resize(inner.period as usize * this.channels as usize, Ch32::MID);
         // Ready for more samples.
-        this.locked.store(true, SeqCst);
+        inner.locked.store(true, SeqCst);
         Poll::Ready(())
     }
 }
 
 pub(crate) struct SpeakersSink<F: Frame<Chan = Ch32>>(
-    *mut Speakers,
+    *mut SpeakersInner,
     Resampler<F>,
     PhantomData<F>,
+    f64,
 );
 
 impl<F: Frame<Chan = Ch32>> Sink<F> for SpeakersSink<F> {
     fn sample_rate(&self) -> f64 {
-        let speakers = unsafe { self.0.as_mut().unwrap() };
-        speakers.sample_rate.unwrap()
+        self.3
     }
 
     fn resampler(&mut self) -> &mut Resampler<F> {

--- a/src/ffi/macos/device_list.rs
+++ b/src/ffi/macos/device_list.rs
@@ -9,15 +9,13 @@
 
 use std::fmt::Display;
 
-pub(crate) trait SoundDevice: Display + From<AudioDevice> {
+pub(crate) trait SoundDevice: Display {
     const INPUT: bool;
 }
 
-pub(crate) struct AudioDevice();
-
 /// Return a list of available audio devices.
 pub(crate) fn device_list<D: SoundDevice, F: Fn(D) -> T, T>(
-    abstrakt: F,
+    _abstrakt: F,
 ) -> Vec<T> {
-    vec![abstrakt(D::from(AudioDevice()))]
+    vec![]
 }

--- a/src/ffi/macos/ffi.rs
+++ b/src/ffi/macos/ffi.rs
@@ -7,12 +7,11 @@
 // At your choosing (See accompanying files LICENSE_APACHE_2_0.txt,
 // LICENSE_MIT.txt and LICENSE_BOOST_1_0.txt).
 
-mod audio_queue;
 mod device_list;
 mod microphone;
 mod speakers;
 
-use device_list::{AudioDevice, SoundDevice};
+use device_list::SoundDevice;
 
 pub(crate) use device_list::device_list;
 pub(super) use microphone::{Microphone, MicrophoneStream};

--- a/src/ffi/macos/microphone.rs
+++ b/src/ffi/macos/microphone.rs
@@ -17,7 +17,7 @@ use std::{
 
 use fon::{chan::Ch32, Frame, Stream};
 
-use super::{AudioDevice, SoundDevice};
+use super::SoundDevice;
 
 pub(crate) struct Microphone();
 
@@ -40,7 +40,7 @@ impl Default for Microphone {
 impl Microphone {
     pub(crate) fn record<F: Frame<Chan = Ch32>>(
         &mut self,
-    ) -> MicrophoneStream<'_, F> {
+    ) -> MicrophoneStream<F> {
         MicrophoneStream(PhantomData)
     }
 
@@ -57,17 +57,11 @@ impl Future for Microphone {
     }
 }
 
-impl From<AudioDevice> for Microphone {
-    fn from(this: AudioDevice) -> Self {
-        Self::default()
-    }
-}
-
-pub(crate) struct MicrophoneStream<'a, F: Frame<Chan = Ch32>>(
-    PhantomData<&'a F>,
+pub(crate) struct MicrophoneStream<F: Frame<Chan = Ch32>>(
+    PhantomData<&'static F>,
 );
 
-impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<F> {
     type Item = F;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -75,7 +69,7 @@ impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<'_, F> {
     }
 }
 
-impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<F> {
     fn sample_rate(&self) -> Option<f64> {
         Some(crate::consts::SAMPLE_RATE.into())
     }

--- a/src/ffi/macos/speakers.rs
+++ b/src/ffi/macos/speakers.rs
@@ -17,7 +17,7 @@ use std::{
 
 use fon::{chan::Ch32, Frame, Resampler, Sink};
 
-use super::{AudioDevice, SoundDevice};
+use super::SoundDevice;
 
 pub(crate) struct Speakers {
     pub(crate) sample_rate: Option<f64>,
@@ -41,16 +41,8 @@ impl Default for Speakers {
     }
 }
 
-impl From<AudioDevice> for Speakers {
-    fn from(this: AudioDevice) -> Self {
-        Self::default()
-    }
-}
-
 impl Speakers {
-    pub(crate) fn play<F: Frame<Chan = Ch32>>(
-        &mut self,
-    ) -> SpeakersSink<'_, F> {
+    pub(crate) fn play<F: Frame<Chan = Ch32>>(&mut self) -> SpeakersSink<F> {
         SpeakersSink(self, Resampler::default(), PhantomData)
     }
 
@@ -59,7 +51,7 @@ impl Speakers {
     }
 }
 
-impl Future for &mut Speakers {
+impl Future for Speakers {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -67,15 +59,17 @@ impl Future for &mut Speakers {
     }
 }
 
-pub(crate) struct SpeakersSink<'a, F: Frame<Chan = Ch32>>(
-    &'a mut Speakers,
+pub(crate) struct SpeakersSink<F: Frame<Chan = Ch32>>(
+    *mut Speakers,
     Resampler<F>,
     PhantomData<F>,
 );
 
-impl<F: Frame<Chan = Ch32>> Sink<F> for SpeakersSink<'_, F> {
+#[allow(unsafe_code)]
+impl<F: Frame<Chan = Ch32>> Sink<F> for SpeakersSink<F> {
     fn sample_rate(&self) -> f64 {
-        self.0.sample_rate.unwrap()
+        let speakers = unsafe { self.0.as_mut().unwrap() };
+        speakers.sample_rate.unwrap()
     }
 
     fn resampler(&mut self) -> &mut Resampler<F> {

--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -10,63 +10,91 @@
 use std::fmt::{Debug, Display, Formatter, Result};
 
 use fon::{chan::Ch32, Frame, Stream};
+use pasts::prelude::*;
 
 use crate::ffi;
 
-/// Record audio samples from a microphone.
+/// Record audio from connected microphone.  Notifier produces an audio stream,
+/// which contains the samples recorded since the previous call.
 #[derive(Default)]
-pub struct Microphone(pub(super) ffi::Microphone);
+pub struct Microphone<const N: usize>(pub(super) ffi::Microphone);
 
-impl Display for Microphone {
+impl<const N: usize> Display for Microphone<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.0.fmt(f)
     }
 }
 
-impl Debug for Microphone {
+impl<const N: usize> Debug for Microphone<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         <Self as Display>::fmt(self, f)
     }
 }
 
-impl Microphone {
+impl<const N: usize> Microphone<N> {
     /// Query available audio sources.
     pub fn query() -> Vec<Self> {
         ffi::device_list(Self)
     }
 
-    /// Check is microphone is available to use in a specific configuration
-    pub fn supports<F>(&self) -> bool
+    /// Try a reconfiguration of microphone.
+    pub fn config<const C: usize>(
+        self,
+    ) -> std::result::Result<Microphone<C>, Self>
     where
-        F: Frame<Chan = Ch32>,
+        Microphone<C>: MicrophoneProperties,
     {
-        let count = F::CHAN_COUNT;
-        let bit = count - 1;
-        (self.0.channels() & (1 << bit)) != 0
+        let bit = C - 1;
+        if (self.0.channels() & (1 << bit)) != 0 {
+            Ok(Microphone(self.0))
+        } else {
+            Err(self)
+        }
     }
+}
 
-    /// Record audio from connected microphone.  Returns an audio stream, which
-    /// contains the samples recorded since the previous call.
-    pub async fn record<F: Frame<Chan = Ch32>>(
-        &mut self,
-    ) -> MicrophoneStream<'_, F> {
-        (&mut self.0).await;
-        MicrophoneStream(self.0.record())
+pub trait MicrophoneProperties {
+    type Sample: Frame<Chan = Ch32>;
+}
+
+impl MicrophoneProperties for Microphone<1> {
+    type Sample = fon::mono::Mono32;
+}
+
+impl MicrophoneProperties for Microphone<2> {
+    type Sample = fon::stereo::Stereo32;
+}
+
+impl MicrophoneProperties for Microphone<6> {
+    type Sample = fon::surround::Surround32;
+}
+
+impl<const N: usize> Notifier for Microphone<N>
+where
+    Microphone<N>: MicrophoneProperties,
+{
+    type Event = MicrophoneStream<<Self as MicrophoneProperties>::Sample>;
+
+    fn poll_next(self: Pin<&mut Self>, e: &mut Exec<'_>) -> Poll<Self::Event> {
+        let this = self.get_mut();
+        if let Ready(()) = Pin::new(&mut this.0).poll(e) {
+            Ready(MicrophoneStream(this.0.record()))
+        } else {
+            Pending
+        }
     }
 }
 
 /// A stream of recorded audio samples from a microphone.
-pub struct MicrophoneStream<'a, F: Frame<Chan = Ch32>>(
-    ffi::MicrophoneStream<'a, F>,
-);
+pub struct MicrophoneStream<F: Frame<Chan = Ch32>>(ffi::MicrophoneStream<F>);
 
-impl<F: Frame<Chan = Ch32>> Debug for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Debug for MicrophoneStream<F> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         write!(fmt, "MicrophoneStream(rate: {:?})", self.sample_rate())
     }
 }
 
-impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<F> {
     type Item = F;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -74,7 +102,7 @@ impl<F: Frame<Chan = Ch32>> Iterator for MicrophoneStream<'_, F> {
     }
 }
 
-impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<'_, F> {
+impl<F: Frame<Chan = Ch32>> Stream<F> for MicrophoneStream<F> {
     fn sample_rate(&self) -> Option<f64> {
         self.0.sample_rate()
     }

--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -31,12 +31,14 @@ impl<const N: usize> Debug for Microphone<N> {
     }
 }
 
-impl<const N: usize> Microphone<N> {
+impl Microphone<0> {
     /// Query available audio sources.
     pub fn query() -> Vec<Self> {
         ffi::device_list(Self)
     }
+}
 
+impl<const N: usize> Microphone<N> {
     /// Try a reconfiguration of microphone.
     pub fn config<const C: usize>(
         self,

--- a/src/speakers.rs
+++ b/src/speakers.rs
@@ -23,45 +23,39 @@ use crate::ffi;
 /// # 440 HZ Sine Wave Example
 /// **note:** This example depends on `twang = "0.5"` to synthesize the sine
 /// wave.
-/// ```no_run
+/// ```
 /// use fon::{stereo::Stereo32, Sink};
-/// use pasts::{exec, wait};
+/// use pasts::{prelude::*, Join};
 /// use twang::{Fc, Signal, Synth};
 /// use wavy::{Speakers, SpeakersSink};
 ///
-/// /// An event handled by the event loop.
-/// enum Event<'a> {
-///     /// Speaker is ready to play more audio.
-///     Play(SpeakersSink<'a, Stereo32>),
-/// }
-///
 /// /// Shared state between tasks on the thread.
-/// struct State {
+/// struct App<'a> {
+///     /// Handle to stereo speakers
+///     speakers: &'a mut Speakers<2>,
 ///     /// A streaming synthesizer using Twang.
 ///     synth: Synth<()>,
 /// }
 ///
-/// impl State {
-///     /// Event loop.  Return false to stop program.
-///     fn event(&mut self, event: Event<'_>) {
-///         match event {
-///             Event::Play(mut speakers) => speakers.stream(&mut self.synth),
+/// impl App<'_> {
+///     /// Speaker is ready to play more audio.
+///     fn play(&mut self, mut sink: SpeakersSink<Stereo32>) -> Poll<()> {
+///         sink.stream(&mut self.synth);
+///         Pending
+///     }
+///
+///     /// Program start.
+///     async fn main(_executor: Executor) {
+///         fn sine(_: &mut (), fc: Fc) -> Signal {
+///             fc.freq(440.0).sine().gain(0.7)
 ///         }
+///
+///         let speakers = &mut Speakers::default();
+///         let synth = Synth::new((), sine);
+///         let mut app = App { speakers, synth };
+///
+///         Join::new(&mut app).on(|s| s.speakers, App::play).await;
 ///     }
-/// }
-///
-/// /// Program start.
-/// fn main() {
-///     fn sine(_: &mut (), fc: Fc) -> Signal {
-///         fc.freq(440.0).sine().gain(0.7)
-///     }
-///
-///     let mut state = State { synth: Synth::new((), sine) };
-///     let mut speakers = Speakers::default();
-///
-///     exec!(state.event(wait! {
-///         Event::Play(speakers.play().await),
-///     }));
 /// }
 /// ```
 #[derive(Default)]

--- a/src/speakers.rs
+++ b/src/speakers.rs
@@ -12,10 +12,13 @@
 use std::fmt::{Debug, Display, Formatter, Result};
 
 use fon::{chan::Ch32, Frame, Resampler, Sink};
+use pasts::prelude::*;
 
 use crate::ffi;
 
-/// Play audio samples through a speaker.
+/// Play audio through speakers.  Notifier produces an audio sink, which
+/// consumes an audio stream of played samples.  If you don't write to the sink,
+/// it will keep playing whatever was last streamed into it.
 ///
 /// # 440 HZ Sine Wave Example
 /// **note:** This example depends on `twang = "0.5"` to synthesize the sine
@@ -62,55 +65,84 @@ use crate::ffi;
 /// }
 /// ```
 #[derive(Default)]
-pub struct Speakers(pub(super) ffi::Speakers);
+pub struct Speakers<const N: usize>(pub(super) ffi::Speakers);
 
-impl Display for Speakers {
+impl<const N: usize> Display for Speakers<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.0.fmt(f)
     }
 }
 
-impl Debug for Speakers {
+impl<const N: usize> Debug for Speakers<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         <Self as Display>::fmt(self, f)
     }
 }
 
-impl Speakers {
+impl<const N: usize> Speakers<N> {
     /// Query available audio destinations.
     pub fn query() -> Vec<Self> {
         ffi::device_list(Self)
     }
 
-    /// Check is speakers are available to use in a specific configuration
-    pub fn supports<F>(&self) -> bool
+    /// Try a reconfiguration of speakers.
+    pub fn config<const C: usize>(
+        self,
+    ) -> std::result::Result<Speakers<C>, Self>
     where
-        F: Frame<Chan = Ch32>,
+        Speakers<C>: SpeakersProperties,
     {
-        let count = F::CHAN_COUNT;
-        let bit = count - 1;
-        (self.0.channels() & (1 << bit)) != 0
+        let bit = C - 1;
+        if (self.0.channels() & (1 << bit)) != 0 {
+            Ok(Speakers(self.0))
+        } else {
+            Err(self)
+        }
     }
+}
 
-    /// Play audio through speakers.  Returns an audio sink, which consumes an
-    /// audio stream of played samples.  If you don't write to the sink, it will
-    /// keep playing whatever was last streamed into it.
-    pub async fn play<F: Frame<Chan = Ch32>>(&mut self) -> SpeakersSink<'_, F> {
-        (&mut self.0).await;
-        SpeakersSink(self.0.play())
+pub trait SpeakersProperties {
+    type Sample: Frame<Chan = Ch32>;
+}
+
+impl SpeakersProperties for Speakers<1> {
+    type Sample = fon::mono::Mono32;
+}
+
+impl SpeakersProperties for Speakers<2> {
+    type Sample = fon::stereo::Stereo32;
+}
+
+impl SpeakersProperties for Speakers<6> {
+    type Sample = fon::surround::Surround32;
+}
+
+impl<const N: usize> Notifier for Speakers<N>
+where
+    Speakers<N>: SpeakersProperties,
+{
+    type Event = SpeakersSink<<Self as SpeakersProperties>::Sample>;
+
+    fn poll_next(self: Pin<&mut Self>, e: &mut Exec<'_>) -> Poll<Self::Event> {
+        let this = self.get_mut();
+        if let Ready(()) = Pin::new(&mut this.0).poll(e) {
+            Ready(SpeakersSink(this.0.play()))
+        } else {
+            Pending
+        }
     }
 }
 
 /// A sink that consumes audio samples and plays them through the speakers.
-pub struct SpeakersSink<'a, F: Frame<Chan = Ch32>>(ffi::SpeakersSink<'a, F>);
+pub struct SpeakersSink<F: Frame<Chan = Ch32>>(ffi::SpeakersSink<F>);
 
-impl<F: Frame<Chan = Ch32>> Debug for SpeakersSink<'_, F> {
+impl<F: Frame<Chan = Ch32>> Debug for SpeakersSink<F> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         write!(fmt, "SpeakersSink(rate: {})", self.sample_rate())
     }
 }
 
-impl<F: Frame<Chan = Ch32>> Sink<F> for SpeakersSink<'_, F> {
+impl<F: Frame<Chan = Ch32>> Sink<F> for SpeakersSink<F> {
     fn sample_rate(&self) -> f64 {
         self.0.sample_rate()
     }

--- a/src/speakers.rs
+++ b/src/speakers.rs
@@ -73,12 +73,14 @@ impl<const N: usize> Debug for Speakers<N> {
     }
 }
 
-impl<const N: usize> Speakers<N> {
+impl Speakers<0> {
     /// Query available audio destinations.
     pub fn query() -> Vec<Self> {
         ffi::device_list(Self)
     }
+}
 
+impl<const N: usize> Speakers<N> {
     /// Try a reconfiguration of speakers.
     pub fn config<const C: usize>(
         self,


### PR DESCRIPTION
 - [x] Turn speakers and microphone into notifiers
 - [x] Box microphone and speaker ffi as MicrophoneInner and SpeakerInner (soundness)
 - [x] Update WebAssembly port
 - [x] Doc tests
 - [x] Query (default to 0 channels?)
 - [x] Add changelog entry
 - [x] Test WebAssembly port